### PR TITLE
Modifications mineures pour cadrer avec la version Scala

### DIFF
--- a/cs/CodageFinal/MulSym.cs
+++ b/cs/CodageFinal/MulSym.cs
@@ -1,6 +1,6 @@
 namespace CodageFinal
 {
-    public interface MulSym<R> : ExpSym<R>
+    public interface MulSym<R>
     {
         R Mul(R r1, R r2);
     }

--- a/cs/CodageFinal/MulSymInt.cs
+++ b/cs/CodageFinal/MulSymInt.cs
@@ -1,6 +1,6 @@
 namespace CodageFinal
 {
-    public class MulSymInt : ExpSymInt, MulSym<int>
+    public class MulSymInt : MulSym<int>
     {
         public int Mul(int r1, int r2) => r1 * r2;
     }

--- a/cs/CodageFinal/MulSymStr.cs
+++ b/cs/CodageFinal/MulSymStr.cs
@@ -1,6 +1,6 @@
 namespace CodageFinal
 {
-    public class MulSymStr : ExpSymStr, MulSym<string>
+    public class MulSymStr : MulSym<string>
     {
         public string Mul(string r1, string r2) => $"{r1} * {r2}";
     }

--- a/cs/CodageFinal/Program.cs
+++ b/cs/CodageFinal/Program.cs
@@ -8,14 +8,14 @@ namespace CodageFinal
         {
             Console.WriteLine(tf1(new ExpSymStr()));
             Console.WriteLine(tf1(new ExpSymInt()));
-            Console.WriteLine(tf2(new MulSymStr()));
-            Console.WriteLine(tf2(new MulSymInt()));
+            Console.WriteLine(tf2(new ExpSymStr(), new MulSymStr()));
+            Console.WriteLine(tf2(new ExpSymInt(), new MulSymInt()));
         }
-
+        
         private static R tf1<R>(ExpSym<R> exp) => 
             exp.Add(exp.Num(8), exp.Neg(exp.Add(exp.Num(1),exp.Num(2))));
 
-        private static R tf2<R>(MulSym<R> mexp) =>
-             mexp.Mul(mexp.Num(3), tf1(mexp));
+        private static R tf2<R>(ExpSym<R> exp, MulSym<R> mexp) =>
+             mexp.Mul(exp.Num(3), tf1(exp));
     }
 }


### PR DESCRIPTION
En C# il n'y a pas d'implicites pour coder les « typesclasses » à la
Scala. Mais peu importe, pour coller à l'approche « Final encoding »,
il suffit de passer les interprètes « ExpSym(Int|String) » et
« MulSym(Int|String) » explicitement... Ce qui est presque bien le cas
dans la version C# précédente.

L'idée de l'extensibilité « à postériori » c'est aussi qu'on peu définir
l'interprète des « ExpSym » et des « MulSym » indépendamment. Définir
« MulSym(Int|String) » en le faisant hériter de « ExpSym(Int|String) »
ne va pas dans ce sens.

Pour cadrer avec la version Scala, la où l'on exprime une contraite
de « typleclass », il faut ici préciser *tous* les interprètes qu'il
faut passer au programme. Par exemple pour « tf2 » il faut expliciter
« new ExpSymInt(), new MulSymInt()) ».